### PR TITLE
Change hierarchy

### DIFF
--- a/meta/census_map_human.tsv
+++ b/meta/census_map_human.tsv
@@ -12,12 +12,12 @@ near-projecting glutamatergic cortical neuron	L5/6 NP	deep layer non-IT	Glutamat
 corticothalamic-projecting glutamatergic cortical neuron	L6 CT	deep layer non-IT	Glutamatergic
 L6 corticothalamic-projecting glutamatergic cortical neuron	L6 CT	deep layer non-IT	Glutamatergic
 L6b glutamatergic cortical neuron	L6b	deep layer non-IT	Glutamatergic
-oligodendrocyte	Oligodendrocyte	Oligodendrocyte	Non-neuron
-oligodendrocyte precursor cell	OPC	OPC	Non-neuron
-astrocyte	Astrocyte	Astrocyte	Non-neuron
-astrocyte of the cerebral cortex	Astrocyte	Astrocyte	Non-neuron
-microglial cell	Microglia	Microglia	Non-neuron
-vascular leptomeningeal cell	VLMC	Vascular	Non-neuron
-pericyte	Pericyte	Vascular	Non-neuron
-cerebral cortex endothelial cell	Endothelial	Vascular	Non-neuron
-endothelial cell	Endothelial	Vascular	Non-neuron
+oligodendrocyte	Oligodendrocyte	Oligodendrocyte	Oligodendrocyte
+oligodendrocyte precursor cell	OPC	OPC	OPC
+astrocyte	Astrocyte	Astrocyte	Astrocyte
+astrocyte of the cerebral cortex	Astrocyte	Astrocyte	Astrocyte
+microglial cell	Microglia	Microglia	Microglia
+vascular leptomeningeal cell	VLMC	Vascular	Vascular
+pericyte	Pericyte	Vascular	Vascular
+cerebral cortex endothelial cell	Endothelial	Vascular	Vascular
+endothelial cell	Endothelial	Vascular	Vascular

--- a/meta/census_map_human.tsv
+++ b/meta/census_map_human.tsv
@@ -12,12 +12,12 @@ near-projecting glutamatergic cortical neuron	L5/6 NP	deep layer non-IT	Glutamat
 corticothalamic-projecting glutamatergic cortical neuron	L6 CT	deep layer non-IT	Glutamatergic
 L6 corticothalamic-projecting glutamatergic cortical neuron	L6 CT	deep layer non-IT	Glutamatergic
 L6b glutamatergic cortical neuron	L6b	deep layer non-IT	Glutamatergic
-oligodendrocyte	Oligodendrocyte	Oligodendrocyte	Oligodendrocyte
-oligodendrocyte precursor cell	OPC	OPC	OPC
-astrocyte	Astrocyte	Astrocyte	Astrocyte
-astrocyte of the cerebral cortex	Astrocyte	Astrocyte	Astrocyte
-microglial cell	Microglia	Microglia	Microglia
-vascular leptomeningeal cell	VLMC	Vascular	Vascular
-pericyte	Pericyte	Vascular	Vascular
-cerebral cortex endothelial cell	Endothelial	Vascular	Vascular
-endothelial cell	Endothelial	Vascular	Vascular
+oligodendrocyte	Oligodendrocyte	Oligodendrocyte	Non-neuron
+oligodendrocyte precursor cell	OPC	OPC	Non-neuron
+astrocyte	Astrocyte	Astrocyte	Non-neuron
+astrocyte of the cerebral cortex	Astrocyte	Astrocyte	Non-neuron
+microglial cell	Microglia	Microglia	Non-neuron
+vascular leptomeningeal cell	VLMC	Vascular	Non-neuron
+pericyte	Pericyte	Vascular	Non-neuron
+cerebral cortex endothelial cell	Endothelial	Vascular	Non-neuron
+endothelial cell	Endothelial	Vascular	Non-neuron

--- a/meta/census_map_human.tsv
+++ b/meta/census_map_human.tsv
@@ -1,23 +1,23 @@
-cell_type	subclass	class	family
-lamp5 GABAergic cortical interneuron	LAMP5	LAMP5	GABAergic
-vip GABAergic cortical interneuron	VIP	VIP	GABAergic
-sncg GABAergic cortical interneuron	SNCG	SNCG	GABAergic
-caudal ganglionic eminence derived GABAergic cortical interneuron	PAX6	PAX6	GABAergic
-pvalb GABAergic cortical interneuron	PVALB	PVALB	GABAergic
-sst GABAergic cortical interneuron	SST	SST	GABAergic
-chandelier pvalb GABAergic cortical interneuron	Chandelier	Chandelier	GABAergic
-L2/3-6 intratelencephalic projecting glutamatergic neuron	L2/3-6 IT	L2/3-6 IT	Glutamatergic
-L5 extratelencephalic projecting glutamatergic cortical neuron	L5 ET	deep layer non-IT	Glutamatergic
-near-projecting glutamatergic cortical neuron	L5/6 NP	deep layer non-IT	Glutamatergic
-corticothalamic-projecting glutamatergic cortical neuron	L6 CT	deep layer non-IT	Glutamatergic
-L6 corticothalamic-projecting glutamatergic cortical neuron	L6 CT	deep layer non-IT	Glutamatergic
-L6b glutamatergic cortical neuron	L6b	deep layer non-IT	Glutamatergic
-oligodendrocyte	Oligodendrocyte	Oligodendrocyte	Non-neuron
-oligodendrocyte precursor cell	OPC	OPC	Non-neuron
-astrocyte	Astrocyte	Astrocyte	Non-neuron
-astrocyte of the cerebral cortex	Astrocyte	Astrocyte	Non-neuron
-microglial cell	Microglia	Microglia	Non-neuron
-vascular leptomeningeal cell	VLMC	Vascular	Non-neuron
-pericyte	Pericyte	Vascular	Non-neuron
-cerebral cortex endothelial cell	Endothelial	Vascular	Non-neuron
-endothelial cell	Endothelial	Vascular	Non-neuron
+cell_type	subclass	class	family	global
+lamp5 GABAergic cortical interneuron	LAMP5	LAMP5	GABAergic	GABAergic
+vip GABAergic cortical interneuron	VIP	VIP	GABAergic	GABAergic
+sncg GABAergic cortical interneuron	SNCG	SNCG	GABAergic	GABAergic
+caudal ganglionic eminence derived GABAergic cortical interneuron	PAX6	PAX6	GABAergic	GABAergic
+pvalb GABAergic cortical interneuron	PVALB	PVALB	GABAergic	GABAergic
+sst GABAergic cortical interneuron	SST	SST	GABAergic	GABAergic
+chandelier pvalb GABAergic cortical interneuron	Chandelier	Chandelier	GABAergic	GABAergic
+L2/3-6 intratelencephalic projecting glutamatergic neuron	L2/3-6 IT	L2/3-6 IT	Glutamatergic	Glutamatergic
+L5 extratelencephalic projecting glutamatergic cortical neuron	L5 ET	deep layer non-IT	Glutamatergic	Glutamatergic
+near-projecting glutamatergic cortical neuron	L5/6 NP	deep layer non-IT	Glutamatergic	Glutamatergic
+corticothalamic-projecting glutamatergic cortical neuron	L6 CT	deep layer non-IT	Glutamatergic	Glutamatergic
+L6 corticothalamic-projecting glutamatergic cortical neuron	L6 CT	deep layer non-IT	Glutamatergic	Glutamatergic
+L6b glutamatergic cortical neuron	L6b	deep layer non-IT	Glutamatergic	Glutamatergic
+oligodendrocyte	Oligodendrocyte	Oligodendrocyte	Oligodendrocyte	Non-neuron
+oligodendrocyte precursor cell	OPC	OPC	OPC	Non-neuron
+astrocyte	Astrocyte	Astrocyte	Astrocyte	Non-neuron
+astrocyte of the cerebral cortex	Astrocyte	Astrocyte	Astrocyte	Non-neuron
+microglial cell	Microglia	Microglia	Microglia	Non-neuron
+vascular leptomeningeal cell	VLMC	Vascular	Vascular	Non-neuron
+pericyte	Pericyte	Vascular	Vascular	Non-neuron
+cerebral cortex endothelial cell	Endothelial	Vascular	Vascular	Non-neuron
+endothelial cell	Endothelial	Vascular	Vascular	Non-neuron

--- a/params.hs.json
+++ b/params.hs.json
@@ -13,6 +13,8 @@
     "ref_keys": [
         "subclass",
         "class",
-        "family"
-    ]
+        "family",
+        "global"
+    ],
+    "outdir_prefix": "2024-07-01/homo_sapiens_new/100/dataset_id/SCT/gap_false"
 }

--- a/scripts/run_hsap_dataset_id_SCT_subsample.sh
+++ b/scripts/run_hsap_dataset_id_SCT_subsample.sh
@@ -25,6 +25,7 @@ for subsample_ref in "${subsample_ref_values[@]}"; do
                     --subsample_query "$subsample_query" \
                     -process.executor slurm \
                     --use_gap false \
+                    --outdir_prefix 2024-07-01/homo_sapiens_new/100/dataset_id/SCT/gap_false \
                     -resume                 
             done
         done

--- a/scripts/run_hsap_test.sh
+++ b/scripts/run_hsap_test.sh
@@ -26,6 +26,7 @@ for subsample_ref in "${subsample_ref_values[@]}"; do
                     --subsample_query "$subsample_query" \
                     -process.executor slurm \
                     --use_gap false \
+                    --outdir_prefix 2024-07-01/homo_sapiens_new/100/dataset_id/SCT/gap_false \
                     -resume 
                 done
 			done


### PR DESCRIPTION
This pull request updates the cell type mapping and configuration to add a new "global" classification for each cell type and ensures downstream processes can utilize this new category. The main changes are in the mapping file and the configuration parameters.

**Cell type mapping updates:**
- Changed human `family` level to discriminate between non-neuronal type (as in mouse `family` level)
- Added a new column, `global`, to the `meta/census_map_human.tsv` file to provide a higher-level grouping for each cell type. Existing rows were updated to include this new classification.

**Configuration changes:**
- Updated the `params.hs.json` configuration to include `global` in the `ref_keys` array, ensuring this new grouping is recognized in downstream processing.
- Set a new `outdir_prefix` for output organization in `params.hs.json`.