### PR TITLE
Nf core reorganization

### DIFF
--- a/bin/classify_all.py
+++ b/bin/classify_all.py
@@ -114,16 +114,17 @@ def main():
     
     query.to_csv(os.path.join(outdir,f"{query_name}_{ref_name}.predictions.{cutoff}.tsv"), index=False, sep="\t")
 
-    #class_metrics = update_classification_report(class_metrics, ref_keys)
-
     # Plot confusion matrices
     for key in ref_keys:
         outdir = os.path.join("confusion")
         os.makedirs(outdir, exist_ok=True)
         plot_confusion_matrix(query_name, ref_name, key, class_metrics[key]["confusion"], output_dir=outdir)
 
-    # Collect F1 scores
-    f1_data = []
+    # get total cell count for the sample
+    total_cell_count = query.shape[0]
+    
+    # Collect per-label classification metrics
+    metrics_records = []
     for key in ref_keys:
         label_metrics = class_metrics[key]["label_metrics"]
         weighted_metrics = class_metrics[key]["weighted_metrics"]
@@ -131,10 +132,10 @@ def main():
         nmi = class_metrics[key]["nmi"]
         ari = class_metrics[key]["ari"]
         overall_accuracy = class_metrics[key]["overall_accuracy"]
-        
+            # get total cell count for the sample
         for label, metrics in label_metrics.items():
             #if label not in ["macro avg", "micro avg", "weighted avg", "accuracy"]:
-                f1_data.append({
+                metrics_records.append({
                     'query': query_name,
                     'study': study_name,
                     'reference': ref_name,
@@ -160,12 +161,13 @@ def main():
                     'overall_accuracy': overall_accuracy,
                     'key': key,
                     'cutoff': cutoff,
-                    'ref_region': ref_region
+                    'ref_region': ref_region,
+                    'total_cell_count': total_cell_count
                 }
         )
 
-    # Save F1 scores to a file
-    df = pd.DataFrame(f1_data)
+    # Save classification metrics to a file
+    df = pd.DataFrame(metrics_records)
     
     fields_dict = {'disease': disease, 'sex': sex, 'dev_stage': dev_stage, 
                    'query_region': query_region, 

--- a/bin/process_query.py
+++ b/bin/process_query.py
@@ -34,7 +34,7 @@ def parse_arguments():
   parser = argparse.ArgumentParser(description="Download model file based on organism, census version, and tree file.")
   parser.add_argument('--model_path', type=str, default="/space/grp/rschwartz/rschwartz/nextflow_eval_pipeline/mmus_minimal/37/d213ce21d8108fd3557e7ffa40b041/scvi-mus_musculus-2025-01-30", help='Path to the scvi model file')
   parser.add_argument('--subsample_query', type=int, help='Number of cells to subsample from the query')
-  parser.add_argument('--relabel_path', type=str, default="//space/grp/rschwartz/rschwartz/nextflow_eval_pipeline/meta/relabel_mus_musculus/GSE247339.2_relabel.tsv")
+  parser.add_argument('--relabel_path', type=str, default="/space/grp/rschwartz/rschwartz/nextflow_eval_pipeline/meta/relabel_mus_musculus/GSE247339.2_relabel.tsv")
   parser.add_argument('--mapping_file', type=str, default = None)
   parser.add_argument('--query_path', type=str, default="/space/grp/rschwartz/rschwartz/get_gemma_data.nf/study_names_mouse.txt_author_true_process_samples_true/h5ad/GSE247339.2/GSE247339.2_1051970_GSM7887408.h5ad")
   parser.add_argument('--batch_key', type=str, default="sample")
@@ -42,7 +42,7 @@ def parse_arguments():
   parser.add_argument('--ref_keys', type=str, nargs='+', default=["subclass", "class", "family", "global"])
   parser.add_argument('--remove_unknown', action='store_true', help='Remove cells with unknown labels')
   parser.add_argument('--nmads', type=int, default=5, help='Number of median absolute deviations for outlier detection')
-  parser.add_argument('--gene_mapping', type=str, default="/space/grp/rschwartz/rschwartz/cell_annotation_cortex.nf/meta/gemma_genes.tsv", help='Path to the gene mapping file')
+  parser.add_argument('--gene_mapping', type=str, default="/space/grp/rschwartz/rschwartz/nextflow_eval_pipeline/assets/meta/gemma_genes.tsv", help='Path to the gene mapping file')
   parser.add_argument('--seed', type=int, default=42)
    
   if __name__ == "__main__":

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -686,14 +686,13 @@ def evaluate_sample_predictions(query, ref_keys, mapping_df):
         precision, recall, f1, support = precision_recall_fscore_support(
             true_labels, predicted_labels, labels=labels, zero_division=np.nan
         )
-        support_proportions = support / support.sum() if support.sum() > 0 else np.zeros_like(support)
 
         class_metrics[key]["label_metrics"] = {
             label: {
                 "precision": precision[i],
                 "recall": recall[i],
                 "f1_score": f1[i],
-                "support": support_proportions[i],
+                "support": support[i],
                 "accuracy": accuracy_score(true_labels == label, predicted_labels == label)
             }
             for i, label in enumerate(labels)
@@ -730,6 +729,7 @@ def evaluate_sample_predictions(query, ref_keys, mapping_df):
             "f1_score": micro_f,
         }
 
+    # get total cell count for the sample
     return class_metrics
 
 

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -729,7 +729,7 @@ def evaluate_sample_predictions(query, ref_keys, mapping_df):
             "f1_score": micro_f,
         }
 
-    # get total cell count for the sample
+
     return class_metrics
 
 

--- a/modules/local/classify_all/main.nf
+++ b/modules/local/classify_all/main.nf
@@ -1,7 +1,8 @@
 process CLASSIFY_ALL {
     label 'process_medium'
     conda '/home/rschwartz/anaconda3/envs/scanpyenv'
-    publishDir "${params.outdir}/${method}/${study_name}/${ref_name}/${query_name}", mode: 'copy'
+    publishDir "${params.outdir}/${method}/${study_name}/${ref_name}/${query_name}", pattern: "**tsv", mode: 'copy'
+    publishDir "${params.outdir}/${method}/${study_name}/${ref_name}/${query_name}", pattern: "confusion/", mode: 'copy'
 
     input:
     val ref_keys

--- a/modules/local/get_census_adata/main.nf
+++ b/modules/local/get_census_adata/main.nf
@@ -1,7 +1,8 @@
 process GET_CENSUS_ADATA {
     label 'process_high'
     conda '/home/rschwartz/anaconda3/envs/scanpyenv'
-    publishDir "${params.outdir}/refs/scvi", mode: 'copy'
+    publishDir "${params.outdir}/refs/scvi", mode: 'copy', pattern: "**_umap.png"
+    publishDir "${params.outdir}/refs/scvi", mode: 'copy', pattern: "refs/*yaml"
 
     input:
     val ref_collections

--- a/modules/local/ref_process_seurat/main.nf
+++ b/modules/local/ref_process_seurat/main.nf
@@ -1,7 +1,7 @@
 process REF_PROCESS_SEURAT {
     label 'process_high'
     conda '/home/rschwartz/anaconda3/envs/r4.3'
-    publishDir "${params.outdir}/refs/seurat", mode: 'copy', pattern: "**.rds"
+    //publishDir "${params.outdir}/refs/seurat", mode: 'copy', pattern: "**.rds"
 
     input:
     path h5ad_file

--- a/params.hs.json
+++ b/params.hs.json
@@ -9,7 +9,7 @@
     ],
     "relabel_q": "/space/grp/rschwartz/rschwartz/nextflow_eval_pipeline/meta/relabel_homo_sapiens/*_relabel.tsv",
     "relabel_r": "/space/grp/rschwartz/rschwartz/nextflow_eval_pipeline/meta/census_map_human.tsv",
-    "queries_adata": "/space/grp/rschwartz/rschwartz/evaluation_data_wrangling/pipeline_queries_hsap/sample_subsets/*h5ad",
+    "queries_adata": "/space/grp/rschwartz/rschwartz/get_gemma_data.nf/all_homo_sapiens_samples/h5ad/*/*h5ad",
     "ref_keys": [
         "subclass",
         "class",


### PR DESCRIPTION
This pull request updates several Nextflow process definitions and configuration parameters to improve file publishing behavior and update input data locations. The main changes involve refining which output files are published by specific processes, disabling an unused output, and updating the path to query data in the configuration.

**File publishing and output management:**

* [`modules/local/classify_all/main.nf`](diffhunk://#diff-271395af52e7dd920524244f7eddf6dd1c66a3ec1e38aee92e16fe01f44f3e2dL4-R5): Changed the `publishDir` directive to only publish files matching `**tsv` and the `confusion/` directory, instead of all files, for more selective output management.
* [`modules/local/get_census_adata/main.nf`](diffhunk://#diff-ccd0ec6ebe2dca23088158db93cc821c1533ea16910f81bf2fccc04c6798c780L4-R5): Refined the `publishDir` directive to only publish files matching `**_umap.png` and YAML files in the `refs/` directory, instead of all files.
* [`modules/local/ref_process_seurat/main.nf`](diffhunk://#diff-2c020a809d2379a74289089ca559a0f86a3c85e503b2ca8a4fba1cbbd32556e9L4-R4): Disabled the `publishDir` directive for RDS files by commenting it out, possibly to prevent unnecessary file outputs or due to changes in workflow requirements.

**Configuration updates:**

* [`params.hs.json`](diffhunk://#diff-a58c99ad9ef4711886df92a79b369241374562e187678b13199c898d9fe0928bL12-R12): Updated the `queries_adata` parameter to point to a new directory structure for query H5AD files, reflecting a change in data organization or source.